### PR TITLE
Update stacks_4_populations.sh

### DIFF
--- a/00-scripts/stacks_4_populations.sh
+++ b/00-scripts/stacks_4_populations.sh
@@ -105,8 +105,4 @@ populations $b $P $M $r $m $g $V $B $W $s $e $t $v $h $r $p $m $a $f \
     $beagle_phased $plink $phylip $phylip_var $hzar $write_single_snp \
     $write_random_snp $log_fst_comp 2>&1 | tee stacks_populations.log
 
-# Correct formating of integers in 8th column of 
-# 05-stacks/batch_1.sumstats.tsv
-
-perl -i.bak -pe 's/\.0000//' 05-stacks/batch_1.sumstats.tsv
 


### PR DESCRIPTION
Deleted the "correct formatting of integers", at the end of the populations script, that was in conflict with newer version of stacks output.
