### PR TITLE
Add cutadapt in PE mode and process_radtags in PE with single enzyme

### DIFF
--- a/00-scripts/01_cutadapt_PE.sh
+++ b/00-scripts/01_cutadapt_PE.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Remove adapters using cutadapt
+TIMESTAMP=$(date +%Y-%m-%d_%Hh%Mm%Ss)
+NCPU=$1
+
+# Copy script as it was run
+SCRIPT=$0
+NAME=$(basename $0)
+LOG_FOLDER="10-log_files"
+
+cp $SCRIPT $LOG_FOLDER/"$TIMESTAMP"_"$NAME"
+
+# Test if user specified a number of CPUs
+if [[ -z "$NCPU" ]]
+then
+    NCPU=1
+fi
+
+# Create directory for untrimmed files
+mkdir 02-raw/trimmed 2>/dev/null
+
+rm 10-log_files/"$TIMESTAMP"_01_cutadapt"${i%.fastq.gz}".log 2> /dev/null
+
+## Single-end mode
+# ls -1 02-raw/*.fastq.gz |
+# parallel -j $NCPU cutadapt -a file:01-info_files/adapters.fasta -A file:01-info_files/adapters.fasta \
+#         -o 02-raw/trimmed/{/} \
+#         -e 0.2 \
+#         -m 50 \
+#         {} '2>&1' '>>' 10-log_files/"$TIMESTAMP"_01_cutadapt"${i%.fastq.gz}".log
+
+
+# Paired-end mode
+ls -1 02-raw/*R1.fastq.gz | 
+        sed 's/R1\.fastq\.gz//g' | 
+        sed 's/02\-raw\///g' |
+parallel -j $NCPU cutadapt -a file:01-info_files/adapters.fasta \
+        -A file:01-info_files/adapters.fasta \
+        -o 02-raw/trimmed/{}"R1.fastq.gz" \
+        -p 02-raw/trimmed/{}"R2.fastq.gz" \
+        -e 0.2 \
+        -m 50 \
+        "02-raw/"{}"R1.fastq.gz" "02-raw/"{}"R2.fastq.gz" '2>&1' '>>' 10-log_files/"$TIMESTAMP"_01_cutadapt.log
+
+

--- a/00-scripts/02_process_radtags_1_enzyme_parallel_pe.sh
+++ b/00-scripts/02_process_radtags_1_enzyme_parallel_pe.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Launch process_radtags on all the lanes
+TIMESTAMP=$(date +%Y-%m-%d_%Hh%Mm%Ss)
+NCPU=$3
+
+# Copy script as it was run
+SCRIPT=$0
+NAME=$(basename "$0")
+LOG_FOLDER="10-log_files"
+INFO_FILES_FOLDER="01-info_files"
+SAMPLE_INFO="sample_information.csv"
+
+cp "$SCRIPT" "$LOG_FOLDER"/"$TIMESTAMP"_"$NAME"
+cp $INFO_FILES_FOLDER/$SAMPLE_INFO $LOG_FOLDER/"$TIMESTAMP"_"$SAMPLE_INFO"
+
+# Test if user specified a number of CPUs
+if [[ -z "$NCPU" ]]
+then
+    NCPU=1
+fi
+
+### Global variable
+INFO_FILES="01-info_files"
+TRIM_LENGTH=$1 # Length to cut reads after process_radtags
+ENZYME1=$2 # Name of the enzyme (run 'process_radtags' without options for list)
+
+# Write command to file
+echo -e "process_radtags command used:\n\n\
+    $(echo process_radtags_2_enzymes.sh $TRIM_LENGTH $ENZYME1 $ENZYME2)" \
+> 10-log_files/process_radtags_2_enzymes_command.log
+
+# Extract reads
+cat $INFO_FILES/lane_info.txt |
+    parallel -j $NCPU ./00-scripts/utility_scripts/process_radtags_1_enzyme_pe.sh "$TRIM_LENGTH" "$ENZYME1" 

--- a/00-scripts/utility_scripts/process_radtags_1_enzyme_pe.sh
+++ b/00-scripts/utility_scripts/process_radtags_1_enzyme_pe.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+### Global variable
+INFO_FILES="01-info_files"
+TRIM_LENGTH=$1 # Length to cut reads after process_radtags
+ENZYME1=$2 # Name of the enzyme (run 'process_radtags' without options for list)
+LANE=$3
+TEMPBARCODES=.temp.${LANE}.barcodes
+
+grep -vE "^$" "$INFO_FILES"/sample_information.csv  | \
+    grep "$LANE" | \
+    grep -v "Barcode" | \
+    cut -f 2 > "$INFO_FILES"/"$TEMPBARCODES"
+
+# Extract the barcodes of all different lengths at once, STACKS 1.23+
+mkdir 03-samples/"$LANE" 2> /dev/null
+
+process_radtags \
+    -i gzfastq \
+    -1 02-raw/trimmed/"$LANE"".fastq.gz" \
+    -2 02-raw/trimmed/$(echo "$LANE" | perl -pe 's/_R1/_R2/')".fastq.gz" \
+    -o 03-samples/"$LANE" \
+    -b "$INFO_FILES"/"$TEMPBARCODES" \
+    -c -r -t "$TRIM_LENGTH" \
+    -q -s 0 \
+    --barcode_dist_1 2 \
+    -E phred33 \
+    --renz_1 "$ENZYME1" 
+
+# Copy log files to ./10-log_files/
+cp 03-samples/"$LANE"/process_radtags.log 10-log_files/"$TIMESTAMP"_02_process_radtags_2_enzymes_"$LANE".log
+
+# Cleanup temp files
+#rm "$INFO_FILES"/"$TEMPBARCODES"


### PR DESCRIPTION
Cutadapt in PE mode to ensure that retained reads match (R1 retained == R2 retained). Script was adapted from existing script conducting cutadapt in SE mode. 
process_radtags in PE mode with a single enzyme rather than two enzymes to accommodate HD-GBS approach as per  [Torkamaneh et al. 2021](https://pubmed.ncbi.nlm.nih.gov/33476468/). 

Reference:
Torkamaneh D, Laroche J, Boyle B, Hyten DL, Belzile F (2021) A bumper crop of SNPs in soybean through high-density genotyping-by-sequencing (HD-GBS). Plant Biotechnology Journal 19, 860-862.
