### PR TITLE
Add new function to reduce pop map based on present samples, update README

### DIFF
--- a/00-scripts/reduce_population_map.sh
+++ b/00-scripts/reduce_population_map.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Reduces population map to only include the samples that were actually present after filters
+#  for example samples with too few reads or other quality issues.
+#  This enables removal of samples that are in sample information file
+#  without disrupting downstream functions
+TIMESTAMP=$(date +%Y-%m-%d_%Hh%Mm%Ss)
+
+# Copy script as it was run
+SCRIPT=$0
+NAME=$(basename $0)
+LOG_FOLDER="10-log_files"
+
+cp $SCRIPT $LOG_FOLDER/"$TIMESTAMP"_"$NAME"
+
+# Global variables
+INFO_FILES="01-info_files"
+SAMPLE_FILES="04-all_samples"
+
+# Create file listing aligned samples that are present in sample folder
+basename -a $SAMPLE_FILES/*.sorted.bam | \
+    sed 's/\.sorted\.bam//g' - > $INFO_FILES/samplelist_present.txt
+
+# Reporting
+echo "Number of samples in the current pop map (full):"  
+wc -l $INFO_FILES/population_map.txt
+
+echo "Reducing pop map down to the number of samples present in $SAMPLE_FILES folder: "
+wc -l $INFO_FILES/samplelist_present.txt
+
+# Select only the present samples from the population map
+grep -f $INFO_FILES/samplelist_present.txt $INFO_FILES/population_map.txt > $INFO_FILES/population_map_present_samples.txt 
+
+# Write over full population map with reduced population map
+mv $INFO_FILES/population_map_present_samples.txt $INFO_FILES/population_map.txt
+
+# Clean workspace
+rm $INFO_FILES/samplelist_present.txt
+
+# Reporting
+echo "Number of samples in the current pop map (reduced):"
+wc -l $INFO_FILES/population_map.txt
+

--- a/README.md
+++ b/README.md
@@ -324,12 +324,13 @@ bwa index ./08-genome/genome.fasta
 
 ### Align samples
 
-Different bwa alignment scripts are available in 00-scripts.
+Different bwa alignment scripts are available in 00-scripts. Add the number
+of cores to use after each script name.
 
 ```bash
 ./00-scripts/bwa_mem_align_reads.sh
 ./00-scripts/bwa_mem_align_reads_by_n_samples.sh
-./00-scripts/bwa_mem_align_reads_PE.sh
+./00-scripts/bwa_mem_align_reads_pe.sh
 ```
 
 ## STACKS pipeline

--- a/README.md
+++ b/README.md
@@ -300,14 +300,6 @@ number of reads per sample. Keep samples with low coverages if you are not sure
 what threshold to use at this point. We will filter the VCF for this later and
 will then have better information then.
 
-Note: if there are samples or populations specified in the population map that
-were deleted due to quality control, this can cause errors in gstacks below. To
-resolve, use the following function to update the population map to only include
-the samples that are present.
-```bash
-./00-scripts/reduce_population_map.sh
-```
-
 #### Align reads to a reference genome (optional)
 
 ##### Install `bwa <http://bio-bwa.sourceforge.net>`
@@ -339,6 +331,15 @@ of cores to use after each script name.
 
 ```bash
 ./00-scripts/04_prepare_population_map.sh
+```
+
+Note: if there are samples or populations specified in the sample information file 
+and therefore are in the created population map but that were deleted above due to 
+quality control, this can cause errors in gstacks below. To resolve, use the 
+following function to update the population map to only include the samples that 
+are present.
+```bash
+./00-scripts/reduce_population_map.sh
 ```
 
 ## Edit script parameters

--- a/README.md
+++ b/README.md
@@ -369,8 +369,8 @@ options.
 ./00-scripts/stacks2_cstacks.sh
 ./00-scripts/stacks2_sstacks.sh
 ./00-scripts/stacks2_tsv2bam.sh
-./00-scripts/stacks2_gstacks.sh
-./00-scripts/stacks2_populations.sh
+./00-scripts/stacks2_gstacks_denovo.sh
+./00-scripts/stacks2_populations_denovo.sh
 ```
 
 ### With a reference genome
@@ -378,8 +378,8 @@ options.
 After the reads are aligned with bwa, run:
 
 ```bash
-./00-scripts/stacks2_gstacks.sh
-./00-scripts/stacks2_populations.sh
+./00-scripts/stacks2_gstacks_reference.sh
+./00-scripts/stacks2_populations_reference.sh
 ```
 ## Filtering the results
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ lane/chip of each sample.
 - The fourth column contains the name of the sample (do not include the
   population name or abbreviation in the sample name).
 - Neither the population name nor the sample name should contain underscores `_`
+  or spaces
 - The fifth column contains a number or string identifying the populations. you
   can use the same as in the third column.
 - The sixth column contains the plate well identifier.

--- a/README.md
+++ b/README.md
@@ -300,6 +300,14 @@ number of reads per sample. Keep samples with low coverages if you are not sure
 what threshold to use at this point. We will filter the VCF for this later and
 will then have better information then.
 
+Note: if there are samples or populations specified in the population map that
+were deleted due to quality control, this can cause errors in gstacks below. To
+resolve, use the following function to update the population map to only include
+the samples that are present.
+```bash
+./00-scripts/reduce_population_map.sh
+```
+
 #### Align reads to a reference genome (optional)
 
 ##### Install `bwa <http://bio-bwa.sourceforge.net>`


### PR DESCRIPTION
New function to reduce the automated population map created from `sample_information.csv` to avoid errors in stacks modules (e.g., gstacks) that can occur if samples or populations are present in the population map but not in the sample folder.  To be run directly after automated population map creation, and avoids needing to change the original `sample_information.csv` file.  

Other changes are minor updates for clarity in the README, including specifying number of cores in scripts as argument, requirements for sample names, or updated script names that are not reflected in README. 