### PR TITLE
Make allele-ratio classification boundaries symmetric under REF/ALT swapping

### DIFF
--- a/00-scripts/09_classify_snps.R
+++ b/00-scripts/09_classify_snps.R
@@ -31,16 +31,21 @@ d$Color[d$MedRatio < 0.20] = lowconf # & d$PropHomRare > 0.00] = lowconf
 d$Color[d$MedRatio > 0.80] = lowconf # & d$PropHomRare > 0.00] = lowconf
 
 # Fis is too negative = duplicated
+# Apply the ratio-dependent boundaries symmetrically around 0.5.
+# Keep MedRatio unchanged for plotting and the original low-confidence checks.
+# This extends the existing low-ratio rules to their high-ratio counterparts;
+# it does not recalibrate or validate the empirical thresholds.
+classification_ratio = pmin(d$MedRatio, 1 - d$MedRatio)
 d$Color[d$Fis < -0.4] = duplicated
-d$Color[d$Fis + d$MedRatio < 0.08] = duplicated
-d$Color[d$Fis + d$MedRatio * 3 < 0.78] = duplicated
-d$Color[d$Fis + d$MedRatio * 8 < 2.3] = duplicated
+d$Color[d$Fis + classification_ratio < 0.08] = duplicated
+d$Color[d$Fis + classification_ratio * 3 < 0.78] = duplicated
+d$Color[d$Fis + classification_ratio * 8 < 2.3] = duplicated
 
 # Very low Fis = diverged
 d$Color[d$Fis < -0.8] = diverged
-d$Color[d$Fis + d$MedRatio * 2 < -0.00] = diverged
-d$Color[d$Fis + d$MedRatio * 3 < 0.20] = diverged
-d$Color[d$Fis + d$MedRatio * 8 < 1.5] = diverged
+d$Color[d$Fis + classification_ratio * 2 < -0.00] = diverged
+d$Color[d$Fis + classification_ratio * 3 < 0.20] = diverged
+d$Color[d$Fis + classification_ratio * 8 < 1.5] = diverged
 
 # High Fis
 d$Color[d$Fis > 0.9] = lowconf

--- a/tests/test_ref_alt_classification.py
+++ b/tests/test_ref_alt_classification.py
@@ -1,0 +1,67 @@
+"""Run unchanged extraction/classification scripts on allele-swapped fixtures.
+
+Usage: python3 tests/test_ref_alt_classification.py [workflow_directory]
+Requires Python 3 and Rscript on PATH; no third-party Python modules.
+All generated files are confined to a temporary directory.
+"""
+import csv
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+root = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else Path(__file__).resolve().parents[1]
+scripts = root / "00-scripts"
+with tempfile.TemporaryDirectory(prefix="stacks-allele-swap-") as temporary:
+    work = Path(temporary)
+    summaries = {}
+    categories = {}
+    for swapped in (False, True):
+        label = "swapped" if swapped else "original"
+        vcf = work / (label + ".vcf")
+        lines = [
+            "##fileformat=VCFv4.2",
+            '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+            '##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">',
+            '##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allele depths">',
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ts1\ts2\ts3\ts4",
+        ]
+        for locus, alternate_depth in enumerate((4, 6, 8, 10, 12, 14, 16), 1):
+            calls = [((0, 0), (20, 0)),
+                     ((0, 1), (20-alternate_depth, alternate_depth)),
+                     ((0, 1), (20-alternate_depth, alternate_depth)),
+                     ((1, 1), (0, 20))]
+            fields = []
+            for gt, ad in calls:
+                if swapped:
+                    gt = tuple(1-a for a in gt)
+                    ad = ad[::-1]
+                fields.append(f"{gt[0]}/{gt[1]}:20:{ad[0]},{ad[1]}")
+            alleles = ["C", "A"] if swapped else ["A", "C"]
+            lines.append("\t".join(["1", str(locus), f"{locus}_1", *alleles,
+                                     ".", "PASS", ".", "GT:DP:AD", *fields]))
+        vcf.write_text("\n".join(lines) + "\n")
+        summary = work / (label + ".tsv")
+        subprocess.run([sys.executable, str(scripts / "08_extract_snp_duplication_info.py"),
+                        str(vcf), str(summary)], check=True, capture_output=True, text=True)
+        subprocess.run(["Rscript", str(scripts / "09_classify_snps.R"), str(summary)],
+                       check=True, capture_output=True, text=True)
+        with summary.open() as handle:
+            summaries[label] = list(csv.DictReader(handle, delimiter="\t"))
+        with Path(str(summary) + ".categorized").open() as handle:
+            categories[label] = list(csv.DictReader(handle, delimiter="\t"))
+    print("ID\toriginal_ratio\tswapped_ratio\tFis\toriginal_category\tswapped_category")
+    changed = 0
+    for a, b, ca, cb in zip(summaries["original"], summaries["swapped"],
+                           categories["original"], categories["swapped"]):
+        assert a["Fis"] == b["Fis"]
+        changed += ca["Category"] != cb["Category"]
+        print("\t".join([a["ID"], a["MedRatio"], b["MedRatio"], a["Fis"],
+                         ca["Category"], cb["Category"]]))
+    print(f"Changed classifications: {changed}/{len(categories['original'])}")
+    assert changed == 0, "REF/ALT swapping changed the classification"
+    expected = ["duplicated", "canonical", "canonical", "canonical",
+                "canonical", "canonical", "duplicated"]
+    assert [x["Category"] for x in categories["original"]] == expected
+    # The raw allele ratios must remain available, not be folded in the output.
+    assert float(summaries["original"][-1]["MedRatio"]) == .8


### PR DESCRIPTION
## Problem

The ratio-dependent duplicated/diverged boundaries currently treat equivalent allele imbalances differently depending on REF/ALT orientation.

For example, with Fis = 0, MedRatio = 0.2 is classified as duplicated, whereas MedRatio = 0.8 is classified as canonical—even when the genotypes and allele depths are consistently relabelled representations of the same data.

## Proposed change

Apply the six ratio-dependent boundaries using:

`min(MedRatio, 1 - MedRatio)`

This reflects the existing low-ratio boundaries around 0.5. Raw ratios remain unchanged for plotting. Other criteria and rule precedence remain unchanged.

This intentionally changes some high-ratio classifications. It does not recalibrate or validate the empirical thresholds, and I welcome discussion of whether this symmetric interpretation matches the intended screening behaviour.

## Regression test

Run:

`python3 tests/test_ref_alt_classification.py`

Requires Python 3 and Rscript.

The test runs the extraction and classification scripts on seven synthetic loci and their consistently allele-swapped equivalents. It checks classification agreement, expected categories, and preservation of raw ratios.

- Original classifier: two classifications differ after swapping; the test fails.
- Proposed classifier: no classifications differ; the test passes.

These are focused synthetic checks, not validation on a biological dataset.

## Scope

This PR addresses the ratio-dependent boundaries only. It does not change carrier-count filtering, project-specific classifiers, or VCF parsing, and does not claim complete allele-label invariance of the entire pipeline.

## Methodological context

McKinney et al. (2017) describe using heterozygosity and deviations from expected 1:1 allele-read balance to identify potential paralogs:

McKinney, G. J., Waples, R. K., Seeb, L. W., & Seeb, J. E. (2017). Paralogs are revealed by proportion of heterozygotes and deviations in read ratios in genotyping-by-sequencing data from natural populations. Molecular Ecology Resources, 17, 656–669. https://doi.org/10.1111/1755-0998.12613

This provides biological context, not validation of these particular thresholds. The proposed change does not implement HDplot or correct mapping-related reference bias.