### PR TITLE
Correct minor-allele carrier counting in the MAS filter

### DIFF
--- a/00-scripts/08_extract_snp_duplication_info.py
+++ b/00-scripts/08_extract_snp_duplication_info.py
@@ -35,7 +35,7 @@ with myopen(input_vcf) as infile:
     with myopen(output_file, "wt") as outfile:
 
         # Write header
-        outfile.write("Scaffold\tPosition\tID\tMedRatio\tAvgRatio\tMedCovHet\tTotCovHet\tMedCovHom\tNumHet\tPropHomFreq\tPropHet\tPropHomRare\tNumRare\tFis\n")
+        outfile.write("Scaffold\tPosition\tID\tMedRatio\tAvgRatio\tMedCovHet\tTotCovHet\tMedCovHom\tNumHet\tPropHomFreq\tPropHet\tPropHomRare\tNumRare\tFis\tNumMinorCarriers\n")
 
         # Iterate over loci and SNPs
         for line in infile:
@@ -94,6 +94,15 @@ with myopen(input_vcf) as infile:
             # proportion heterozygotes (only these with a genotype)
             num_heterozygotes = len(coverages_heterozygotes)
             num_rare = len(coverages_homozygotes_rares) + len(coverages_heterozygotes)
+            # Preserve legacy NumRare (ALT carriers with usable allele depths).
+            # MAS counts individuals, not allele copies, using called genotypes.
+            # For biallelic diploids the less frequent homozygote class identifies
+            # the minor allele; a heterozygote carries either allele once.
+            called_genotypes = [x.split(":")[0] for x in l[9:]]
+            num_minor_carriers = (
+                sum(g in ("0/1", "1/0") for g in called_genotypes)
+                + min(called_genotypes.count("0/0"), called_genotypes.count("1/1"))
+            )
 
             prop_heterozygotes = len(coverages_heterozygotes) / num_samples
 
@@ -132,7 +141,8 @@ with myopen(input_vcf) as infile:
                     prop_heterozygotes,
                     prop_homozygotes_rare,
                     num_rare,
-                    fis
+                    fis,
+                    num_minor_carriers
                     ]
 
             info = [str(x) for x in snp_info]

--- a/00-scripts/09_classify_snps.R
+++ b/00-scripts/09_classify_snps.R
@@ -7,6 +7,14 @@ output_file = paste0(input_file, ".categorized")
 
 # Load data
 data = read.table(input_file, header=T, stringsAsFactors=F)
+if (!"NumMinorCarriers" %in% names(data)) {
+    stop("Missing NumMinorCarriers: rerun 08_extract_snp_duplication_info.py with the updated script.")
+}
+if (any(!is.finite(data$NumMinorCarriers) |
+        data$NumMinorCarriers < 0 |
+        data$NumMinorCarriers != floor(data$NumMinorCarriers))) {
+    stop("NumMinorCarriers must contain non-negative integer counts.")
+}
 d = data[,c("MedRatio", "PropHet", "PropHomRare", "Fis", "MedCovHom", "MedCovHet")]
 
 canonical =     "#00000011" # black
@@ -46,7 +54,7 @@ d$Color[d$Fis + d$MedRatio * 8 < 1.5] = diverged
 d$Color[d$Fis > 0.9] = lowconf
 
 # Too few samples with rare allele
-d$Color[data$NumHet + data$NumRare < 3] = mas
+d$Color[data$NumMinorCarriers < 3] = mas
 
 # Extract bad loci infos
 bad_snps = d$Color != canonical

--- a/tests/test_minor_carriers.py
+++ b/tests/test_minor_carriers.py
@@ -1,0 +1,58 @@
+"""Run with python3 tests/test_minor_carriers.py [workflow_directory].
+
+Requires Python 3 and Rscript. Generated files are confined to a temporary
+directory. Tests use supported unphased biallelic diploid genotypes.
+"""
+import csv
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+root = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else Path(__file__).resolve().parents[1]
+scripts = root / "00-scripts"
+cases = [(8, 2, 0), (7, 3, 0), (8, 0, 2), (7, 0, 3), (8, 1, 1), (7, 1, 2)]
+with tempfile.TemporaryDirectory(prefix="stacks-mas-") as temporary:
+    work = Path(temporary)
+    for swapped in (False, True):
+        rows = ["##fileformat=VCFv4.2",
+                '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+                '##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">',
+                '##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allele depths">',
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t"
+                + "\t".join(f"s{i}" for i in range(10))]
+        for index, (rr, het, aa) in enumerate(cases, 1):
+            calls = [((0, 0), (20, 0))] * rr + [((0, 1), (10, 10))] * het + [((1, 1), (0, 20))] * aa
+            fields = []
+            for gt, ad in calls:
+                if swapped:
+                    gt, ad = tuple(1-a for a in gt), ad[::-1]
+                fields.append(f"{gt[0]}/{gt[1]}:20:{ad[0]},{ad[1]}")
+            alleles = ["C", "A"] if swapped else ["A", "C"]
+            rows.append("\t".join(["1", str(index), f"{index}_1", *alleles,
+                                    ".", "PASS", ".", "GT:DP:AD", *fields]))
+        vcf = work / f"input_{swapped}.vcf"
+        vcf.write_text("\n".join(rows) + "\n")
+        summary = work / f"summary_{swapped}.tsv"
+        subprocess.run([sys.executable, str(scripts / "08_extract_snp_duplication_info.py"),
+                        str(vcf), str(summary)], check=True)
+        subprocess.run(["Rscript", str(scripts / "09_classify_snps.R"), str(summary)], check=True)
+        with summary.open() as handle:
+            stats = list(csv.DictReader(handle, delimiter="\t"))
+        with Path(str(summary) + ".categorized").open() as handle:
+            categories = list(csv.DictReader(handle, delimiter="\t"))
+        assert len(stats) == len(categories) == len(cases)
+        for (rr, het, aa), row, category in zip(cases, stats, categories):
+            expected = het + min(rr, aa)
+            assert int(row["NumMinorCarriers"]) == expected
+            assert int(row["NumRare"]) == het + (rr if swapped else aa)
+            assert (category["Category"] == "mas") == (expected < 3)
+    # Old summaries fail explicitly, rather than silently using legacy counts.
+    legacy = work / "legacy.tsv"
+    lines = summary.read_text().splitlines()
+    legacy.write_text("\n".join(line.rsplit("\t", 1)[0] for line in lines) + "\n")
+    result = subprocess.run(["Rscript", str(scripts / "09_classify_snps.R"), str(legacy)],
+                            capture_output=True, text=True)
+    assert result.returncode != 0
+    assert "Missing NumMinorCarriers" in result.stderr
+print("PASS: carrier counts, allele swaps, threshold boundaries, legacy counts and old-input rejection")


### PR DESCRIPTION
## Problem

The default classifier applies the MAS filter using `NumHet + NumRare`, but the extraction script already includes heterozygotes in `NumRare`. Heterozygotes are therefore counted twice.

Additionally, `NumRare` counts ALT carriers, although ALT is not necessarily the minor allele.

For example, eight REF homozygotes and two heterozygotes currently give a filtering count of four, despite only two individuals carrying the minor allele.

## Proposed change

Add `NumMinorCarriers`, calculated from called, unphased biallelic diploid genotypes as:

`number of heterozygotes + min(number of REF homozygotes, number of ALT homozygotes)`

Use this count directly in the existing minimum-three-carrier filter.

The legacy `NumRare` column remains unchanged. The classifier explicitly rejects older summaries without the new column and instructs users to rerun extraction.

## Regression coverage

Run:

`python3 tests/test_minor_carriers.py`

Requires Python 3 and Rscript.

The end-to-end test covers six genotype configurations and their REF/ALT-swapped equivalents, checking:

- Two-versus-three-carrier thresholds.
- Heterozygous, homozygous, and mixed carriers.
- Allele-label-independent carrier counts.
- Preservation of legacy NumRare values.
- An informative error for older summaries.

All checks passed locally.

## Scope

This corrects the carrier count while retaining the threshold of three individuals. Passing this criterion does not imply that a locus passes the other classification rules.

Broader VCF parsing, unsupported genotype representations, project-specific classifiers, and the allele-ratio changes proposed in #46 are outside this PR.