### PR TITLE
Preserve missing genotypes when no complete donor calls are available

### DIFF
--- a/00-scripts/13_impute_missing_pairwise_distances.py
+++ b/00-scripts/13_impute_missing_pairwise_distances.py
@@ -3,11 +3,13 @@
 
 Usage:
     <program> input_vcf input_distances number_closest output_vcf
+
+Missing calls are retained unchanged when selected neighbours provide no
+fully called donor genotype. Such calls are not counted as imputed.
 """
 
 # Modules
 from collections import Counter
-import numpy
 import gzip
 import sys
 
@@ -23,10 +25,11 @@ def impute(closest_genotypes):
     """Impute using most frequent genotype from closely related samples
     """
     genotypes = [x.split(":")[0] for x in closest_genotypes]
-    genotypes = [x for x in genotypes if x != "./."]
+    # Missing or partially missing donor calls provide no complete genotype.
+    genotypes = [x for x in genotypes if "." not in x]
 
     if not genotypes:
-        genotype = "0/0"
+        return None
     else:
         # Impute most frequent genotype
         counts = Counter(genotypes)
@@ -98,8 +101,12 @@ with myopen(input_vcf) as infile:
                 num_genotypes += 1
 
                 if genotype.startswith("./."):
-                    new_data.append(impute(closest_genotypes))
-                    num_imputed += 1
+                    replacement = impute(closest_genotypes)
+                    if replacement is None:
+                        new_data.append(genotype)
+                    else:
+                        new_data.append(replacement)
+                        num_imputed += 1
 
                 else:
                     new_data.append(genotype)

--- a/tests/test_no_donor_imputation.py
+++ b/tests/test_no_donor_imputation.py
@@ -1,0 +1,54 @@
+"""Run: python3 tests/test_no_donor_imputation.py [workflow_directory].
+
+Tests the CLI using temporary fixtures; requires Python 3 only.
+"""
+import gzip
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+root = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else Path(__file__).resolve().parents[1]
+script = root / "00-scripts/13_impute_missing_pairwise_distances.py"
+missing = "./.:7:3,4:.:."
+called = "1/1:20:0,20:99:100,50,0"
+with tempfile.TemporaryDirectory(prefix="stacks-no-donor-") as temporary:
+    work = Path(temporary)
+    distances = work / "distances.tsv"
+    # Unique zero self-distances isolate this test from the neighbour-tie issue.
+    distances.write_text("a\ta\t0\na\tb\t1\na\tc\t2\nb\ta\t1\nb\tb\t0\nb\tc\t1\nc\ta\t2\nc\tb\t1\nc\tc\t0\n")
+    cases = [("all_missing", [missing]*3, 1, [missing]*3, 0),
+             ("empty_neighbours", [missing, called, called], 0, [missing, called, called], 0),
+             ("one_imputed", [missing, called, called], 1,
+              ["1/1:0:0,0:0:0,0,0", called, called], 1),
+             ("partial_donor", [missing, "0/.:7:3,4:.:.", called], 1,
+              [missing, "0/.:7:3,4:.:.", called], 0),
+             ("dot_donor", [missing, ".:7:3,4:.:.", called], 1,
+              [missing, ".:7:3,4:.:.", called], 0)]
+    for compressed in (False, True):
+        for name, calls, neighbours, expected, count in cases:
+            extension = ".vcf.gz" if compressed else ".vcf"
+            source = work / (name + extension)
+            output = work / (name + ".output" + extension)
+            text = '\n'.join([
+                "##fileformat=VCFv4.3",
+                '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+                '##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">',
+                '##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allele depths">',
+                '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">',
+                '##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Likelihoods">',
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ta\tb\tc",
+                "\t".join(["1", "1", "1_1", "A", "C", ".", "PASS", ".", "GT:DP:AD:GQ:PL", *calls]),
+            ]) + '\n'
+            opener = gzip.open if compressed else open
+            with opener(source, "wt") as handle:
+                handle.write(text)
+            result = subprocess.run([sys.executable, str(script), str(source), str(distances),
+                                     str(neighbours), str(output)], capture_output=True, text=True)
+            assert result.returncode == 0, result.stderr
+            with opener(output, "rt") as handle:
+                lines = handle.read().splitlines()
+            assert lines[-1].split("\t")[9:] == expected, name
+            assert f"({count}/3)" in result.stdout, result.stdout
+            assert lines[:-1] == text.splitlines()[:-1]
+print("PASS: unsupported imputations stay missing; supported calls and counts; plain/gzip input")


### PR DESCRIPTION
## Problem

When none of the selected neighbours has an available genotype, the pairwise-distance imputer currently assigns `0/0`.

That introduces a reference-homozygote call without donor evidence and counts it as a successful imputation.

## Proposed change

- Return no replacement when no complete donor genotype is available.
- Preserve the original missing sample field unchanged.
- Increment the imputation count only when a replacement is made.
- Exclude partially missing donor calls.
- Remove the unused NumPy import.

## Validation

Run:

`python3 tests/test_no_donor_imputation.py`

Requires Python 3 only.

All 10 CLI test runs passed locally: five cases each for plain and gzipped VCFs. They cover missing donors, empty neighbour sets, partially missing donors, and a successful imputation.

The tests check exact preservation of unresolved sample fields, unchanged headers, and reported imputation counts.

## Scope

The existing target-call trigger, neighbour selection, modal-genotype selection, and supporting fields written for successful imputations remain unchanged.

This is a narrow safeguard against unsupported genotype creation, not a validation of the imputation method.