### PR TITLE
Exclude self-neighbours by sample identity before selecting donors

### DIFF
--- a/00-scripts/13_impute_missing_pairwise_distances.py
+++ b/00-scripts/13_impute_missing_pairwise_distances.py
@@ -7,7 +7,6 @@ Usage:
 
 # Modules
 from collections import Counter
-import numpy
 import gzip
 import sys
 
@@ -55,13 +54,15 @@ samples = set([x[0] for x in distances])
 closest_samples = dict()
 
 for s in samples:
-    data = [x for x in distances if x[0] == s]
+    # Exclude self by identity: another sample can also have distance zero,
+    # and input files need not include self-comparisons.
+    data = [x for x in distances if x[0] == s and x[1] != s]
 
     # Decorate and sort
     data = sorted([[x[2]] + x for x in data])
 
     # Extract wanted samples
-    data = [x[2] for x in data[1: 1 + number_closest]]
+    data = [x[2] for x in data[:number_closest]]
     closest_samples[s] = data
 
 # Process VCF

--- a/tests/test_self_neighbours.py
+++ b/tests/test_self_neighbours.py
@@ -1,0 +1,47 @@
+"""Run: python3 tests/test_self_neighbours.py [workflow_directory].
+
+Exercises the CLI with Python 3 only. Files are confined to a temporary directory.
+"""
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+root = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else Path(__file__).resolve().parents[1]
+script = root / "00-scripts/13_impute_missing_pairwise_distances.py"
+with tempfile.TemporaryDirectory(prefix="stacks-self-neighbours-") as temporary:
+    work = Path(temporary)
+    vcf = work / "input.vcf"
+    calls = ["1/1:20:0,20:99:100,50,0", "./.:.:.:.:.", "0/0:20:20,0:99:0,50,100"]
+    vcf.write_text('\n'.join([
+        "##fileformat=VCFv4.3",
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">',
+        '##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allele depths">',
+        '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">',
+        '##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Likelihoods">',
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ta\tb\tc",
+        "\t".join(["1", "1", "1_1", "A", "C", ".", "PASS", ".", "GT:DP:AD:GQ:PL", *calls]),
+    ]) + '\n')
+    checks = 0
+    # a sorts before b. With a tied zero distance, dropping the first row
+    # removes the valid donor a instead of the missing target b.
+    for donor_distance in (0, .1):
+        for include_self in (False, True):
+            rows = [(a, b, 0 if a == b else donor_distance if {a,b} == {"a","b"} else 1)
+                    for a in ("a", "b", "c") for b in ("a", "b", "c")
+                    if include_self or a != b]
+            for reverse in (False, True):
+                checks += 1
+                distances = work / f"distances_{checks}.tsv"
+                ordered = list(reversed(rows)) if reverse else rows
+                distances.write_text("\n".join("\t".join(map(str, row)) for row in ordered) + "\n")
+                output = work / f"output_{checks}.vcf"
+                result = subprocess.run([sys.executable, str(script), str(vcf), str(distances), "1", str(output)],
+                                        capture_output=True, text=True)
+                assert result.returncode == 0, result.stderr
+                fields = output.read_text().splitlines()[-1].split("\t")[9:]
+                assert fields[0] == calls[0] and fields[2] == calls[2]
+                assert fields[1].split(":")[0] == "1/1", (donor_distance, include_self, reverse, fields)
+                assert "(1/3)" in result.stdout
+    print(f"PASS: {checks} CLI cases for self exclusion, zero-distance ties and input order")


### PR DESCRIPTION
## Problem

Neighbour selection currently sorts the distance records and discards the first entry, assuming it is the self-comparison.

That assumption fails when another sample also has distance zero and sorts first. It also discards a valid nearest neighbour when the input contains no self-comparisons.

## Proposed change

Exclude records whose source and target sample IDs match before sorting, then select the requested number of remaining neighbours.

Also remove the unused NumPy import.

## Validation

Run:

`python3 tests/test_self_neighbours.py`

Requires Python 3 only.

All eight CLI cases passed locally, covering:

- Zero-distance ties.
- Distance files with and without self-comparisons.
- Reordered distance rows.
- Ordinary unique zero self-distances.

The tests verify the selected donor’s genotype, preservation of observed calls, and reported imputation counts.

## Scope

The no-donor fallback is addressed separately in #49. Modal-genotype selection, supporting fields written for successful imputations, and general input validation remain unchanged.

This corrects donor selection; it does not establish the statistical validity of nearest-neighbour imputation.